### PR TITLE
Fixing Spanish translation strings

### DIFF
--- a/src/languages/es.json
+++ b/src/languages/es.json
@@ -1,21 +1,21 @@
 {
   "translation": {
-    "title": "¡Aplicación del tiempo que necesitas!",
+    "title": "¡La aplicación del tiempo que necesitas!",
     "today": "Hoy",
     "explore": "#Explorar ?",
-    "more-on": "Más en",
+    "more-on": "Más de",
     "no-data": "No hay datos",
-    "unknown-location": "Localizacion desconocida",
-    "realFell": "Sensacion Real",
+    "unknown-location": "Localización desconocida",
+    "realFell": "Sensación Real",
     "humidity": "Humedad",
-    "cover": "Tapar",
-    "min-temp": "Min Temp",
-    "max-temp": "Max Temp",
+    "cover": "Cubierto",
+    "min-temp": "Mínima",
+    "max-temp": "Máxima",
     "languages": {
       "en": "Inglés",
       "es": "Español",
-      "fr": "Frances",
-      "id": "Indonesia",
+      "fr": "Francés",
+      "id": "Indonesio",
       "ta": "Tamil"
     }
   }


### PR DESCRIPTION
Correction of the wrong Spanish translation strings.

I've also spotted some mistakes in the French one, but I pass and give the opportunity to another person to do it.
So, you may add a new issue to give new contributors this task to do; with the goal of correcting the French translation file `fr.json` and tagging it with the label `hacktoberfest`.

Also have a look and investigate on the `explore` translation string (app.js line 191) 😉

All the best 🌊 