### PR TITLE
Corrected a wrong line  in the contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 1. Fork the repository (Click the Fork button in the top right of this page, click your Profile Image)
 2. Clone the forked repository to your local machine.
 ```markdown
-https://github.com/HridoyHazard/HazzWeather.git
+    git clone https://github.com/<your-username>/HazzWeather.git
 ```
 3. change the present working directory
 ```markdown


### PR DESCRIPTION
I corrected a wrong line in the contribution guide
line 6   -- https://github.com/HridoyHazard/HazzWeather.git--
should be  -- git clone https://github.com/your-username/HazzWeather.git --
This is the command line to clone the forked  repository to your local machine