### PR TITLE
fixed issue #24 where location wasn't updating

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -99,6 +99,7 @@ function App() {
       let data = await res.json();
       if (data.cod !== '200') {
         setNoData('Location Not Found');
+        setCity('Unknown Location')
         setTimeout(() => {
           setLoading(false);
         }, 500);


### PR DESCRIPTION
Previously, location was updating after after entering a wrong location followed by a correct location. Ideally it should be showing **unknown location** after entering a wrong location but instead it was showing the location of **previous** searched location. I fixed this issue.